### PR TITLE
Fixed Image Rotation & MultiSelect 

### DIFF
--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/CameraPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/CameraPickerActivity.java
@@ -12,8 +12,12 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.MediaStore;
+import android.util.Log;
+
+import com.shz.imagepicker.imagepicker.util.FileOrientationHandler;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
 public class CameraPickerActivity extends Activity {
@@ -26,6 +30,7 @@ public class CameraPickerActivity extends Activity {
     private static final String FILE_PROVIDER_PREFIX = ".provider";
 
     private String mFilename;
+    private FileOrientationHandler fileOrientationHandler = new FileOrientationHandler();
 
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
@@ -47,6 +52,13 @@ public class CameraPickerActivity extends Activity {
             Uri uri = ImagePath.getCaptureImageResultUri(this, data, mFilename);
             Uri uriFile = ImagePath.getNormalizedUri(this, uri);
             File file = new File(uriFile.getPath());
+
+            try{
+                fileOrientationHandler.rotateAndReWriteImageFile(file);
+            }catch (IOException e){
+                Log.d(this.getClass().getSimpleName(),"Error rotation image "+e.getLocalizedMessage());
+            }
+
             files.add(file);
             mCallback.onImagesSelected(files);
         }
@@ -94,4 +106,7 @@ public class CameraPickerActivity extends Activity {
             startActivityForResult(cameraIntent, IMAGE_REQUEST_CAMERA);
         }
     }
+
+
+
 }

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
@@ -48,7 +48,7 @@ public class GalleryMultiPickerActivity extends Activity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (resultCode == Activity.RESULT_OK && requestCode == IMAGE_REQUEST_GALLERY) {
-            if (data != null && data.getData() != null) {
+            if (data != null) {
                 ArrayList<File> files = new ArrayList<>();
 
                 /*if (data.getData() != null) {

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
@@ -5,9 +5,11 @@ import android.app.Activity;
 import android.content.ClipData;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.provider.MediaStore;
 import android.util.Log;
 
@@ -15,6 +17,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 
 public class GalleryMultiPickerActivity extends Activity {
@@ -22,7 +25,7 @@ public class GalleryMultiPickerActivity extends Activity {
     public static ImagePickerCallback mCallback;
 
     private static final int PERMISSION_REQUEST_READ_STORAGE = 54564;
-    private static final int IMAGE_REQUEST_GALLERY = 54565;
+    private static final int IMAGE_REQUEST_GALLERY = 1;
 
     private static final String GALLERY_IMAGE_MIME = "image/jpeg";
 
@@ -48,8 +51,25 @@ public class GalleryMultiPickerActivity extends Activity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (resultCode == Activity.RESULT_OK && requestCode == IMAGE_REQUEST_GALLERY) {
+
+
+
             if (data != null) {
                 ArrayList<File> files = new ArrayList<>();
+
+
+                if(data.getExtras() != null){
+                    ArrayList<Parcelable> fileUris = data.getExtras().getParcelableArrayList("selectedItems");
+
+                    for(Parcelable uri : fileUris){
+                        if(uri instanceof Uri){
+                            files.add(new File( getRealPathFromURI((Uri) uri) ) );
+                        }
+
+                    }
+
+
+                }
 
                 if (data.getData() != null) {
                     Log.d("MultiPicker", "data: " + data.getData().toString());
@@ -59,7 +79,7 @@ public class GalleryMultiPickerActivity extends Activity {
                         files.add(file);
                     }
                 }
-                
+
                 if (data.getClipData() != null) {
                     ClipData clipData = data.getClipData();
 
@@ -79,6 +99,18 @@ public class GalleryMultiPickerActivity extends Activity {
         finish();
     }
 
+    public String getRealPathFromURI (Uri contentUri) {
+        String path = null;
+        String[] proj = { MediaStore.MediaColumns.DATA };
+        Cursor cursor = getContentResolver().query(contentUri, proj, null, null, null);
+        if (cursor.moveToFirst()) {
+            int column_index = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA);
+            path = cursor.getString(column_index);
+        }
+        cursor.close();
+        return path;
+    }
+
     private void checkGalleryPermission() {
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED
                 || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
@@ -93,18 +125,16 @@ public class GalleryMultiPickerActivity extends Activity {
     }
 
     private void startGalleryPicker() {
-//        Intent galleryIntent = new Intent(Intent.ACTION_GET_CONTENT, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
-//
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-//            galleryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
-//        }
-//        galleryIntent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, GALLERY_IMAGE_MIME);
-//        startActivityForResult(galleryIntent, IMAGE_REQUEST_GALLERY);
+        Intent galleryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
 
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.setType("image/*"); //allows any image file type. Change * to specific extension to limit it
-//**The following line is the important one!
-        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
-        startActivityForResult(Intent.createChooser(intent, "Select Pictures"), IMAGE_REQUEST_GALLERY); //SELECT_PICTURES is simply a global int used to check the calling intent in onActivityResult
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            galleryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        }
+        galleryIntent.putExtra("multi-pick", true);
+
+
+        //galleryIntent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, GALLERY_IMAGE_MIME);
+        startActivityForResult(galleryIntent, IMAGE_REQUEST_GALLERY);
+        
     }
 }

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
@@ -16,7 +16,10 @@ import android.util.Log;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
+import com.shz.imagepicker.imagepicker.util.FileOrientationHandler;
+
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 
@@ -28,6 +31,7 @@ public class GalleryMultiPickerActivity extends Activity {
     private static final int IMAGE_REQUEST_GALLERY = 1;
 
     private static final String GALLERY_IMAGE_MIME = "image/jpeg";
+    private FileOrientationHandler fileOrientationHandler = new FileOrientationHandler();
 
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
@@ -53,17 +57,16 @@ public class GalleryMultiPickerActivity extends Activity {
         if (resultCode == Activity.RESULT_OK && requestCode == IMAGE_REQUEST_GALLERY) {
 
 
-
             if (data != null) {
                 ArrayList<File> files = new ArrayList<>();
 
 
-                if(data.getExtras() != null){
+                if (data.getExtras() != null) {
                     ArrayList<Parcelable> fileUris = data.getExtras().getParcelableArrayList("selectedItems");
 
-                    for(Parcelable uri : fileUris){
-                        if(uri instanceof Uri){
-                            files.add(new File( getRealPathFromURI((Uri) uri) ) );
+                    for (Parcelable uri : fileUris) {
+                        if (uri instanceof Uri) {
+                            files.add(new File(getRealPathFromURI((Uri) uri)));
                         }
 
                     }
@@ -93,15 +96,26 @@ public class GalleryMultiPickerActivity extends Activity {
                     }
                 }
 
+
+                try {
+                    for (File file :
+                            files) {
+                        fileOrientationHandler.rotateAndReWriteImageFile(file);
+                    }
+                } catch (IOException e) {
+                    Log.d(this.getClass().getSimpleName(), "Error rotating image " + e.getLocalizedMessage());
+                }
+
+
                 mCallback.onImagesSelected(files);
             }
         }
         finish();
     }
 
-    public String getRealPathFromURI (Uri contentUri) {
+    public String getRealPathFromURI(Uri contentUri) {
         String path = null;
-        String[] proj = { MediaStore.MediaColumns.DATA };
+        String[] proj = {MediaStore.MediaColumns.DATA};
         Cursor cursor = getContentResolver().query(contentUri, proj, null, null, null);
         if (cursor.moveToFirst()) {
             int column_index = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA);
@@ -116,7 +130,7 @@ public class GalleryMultiPickerActivity extends Activity {
                 || ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED) {
             ActivityCompat.requestPermissions(
                     this,
-                    new String[] { Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE },
+                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE},
                     PERMISSION_REQUEST_READ_STORAGE
             );
         } else {
@@ -135,6 +149,6 @@ public class GalleryMultiPickerActivity extends Activity {
 
         //galleryIntent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, GALLERY_IMAGE_MIME);
         startActivityForResult(galleryIntent, IMAGE_REQUEST_GALLERY);
-        
+
     }
 }

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
@@ -92,12 +92,18 @@ public class GalleryMultiPickerActivity extends Activity {
     }
 
     private void startGalleryPicker() {
-        Intent galleryIntent = new Intent(Intent.ACTION_GET_CONTENT, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+//        Intent galleryIntent = new Intent(Intent.ACTION_GET_CONTENT, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+//
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+//            galleryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+//        }
+//        galleryIntent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, GALLERY_IMAGE_MIME);
+//        startActivityForResult(galleryIntent, IMAGE_REQUEST_GALLERY);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            galleryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
-        }
-        galleryIntent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, GALLERY_IMAGE_MIME);
-        startActivityForResult(galleryIntent, IMAGE_REQUEST_GALLERY);
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.setType("image/*"); //allows any image file type. Change * to specific extension to limit it
+//**The following line is the important one!
+        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        startActivityForResult(Intent.createChooser(intent, "Select Pictures"), IMAGE_REQUEST_GALLERY); //SELECT_PICTURES is simply a global int used to check the calling intent in onActivityResult
     }
 }

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
@@ -51,14 +51,14 @@ public class GalleryMultiPickerActivity extends Activity {
             if (data != null) {
                 ArrayList<File> files = new ArrayList<>();
 
-                /*if (data.getData() != null) {
+                if (data.getData() != null) {
                     Log.d("MultiPicker", "data: " + data.getData().toString());
                     String filename = ImagePath.getImagePathFromInputStreamUri(this, data.getData());
                     File file = new File(filename);
                     if (file.exists()) {
                         files.add(file);
                     }
-                }*/
+                }
                 if (data.getClipData() != null) {
                     ClipData clipData = data.getClipData();
 

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
@@ -59,6 +59,7 @@ public class GalleryMultiPickerActivity extends Activity {
                         files.add(file);
                     }
                 }
+                
                 if (data.getClipData() != null) {
                     ClipData clipData = data.getClipData();
 

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GalleryMultiPickerActivity.java
@@ -92,8 +92,9 @@ public class GalleryMultiPickerActivity extends Activity {
     }
 
     private void startGalleryPicker() {
-        Intent galleryIntent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
-        if (Build.VERSION.SDK_INT >= 18) {
+        Intent galleryIntent = new Intent(Intent.ACTION_GET_CONTENT, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             galleryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         }
         galleryIntent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, GALLERY_IMAGE_MIME);

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GallerySinglePickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GallerySinglePickerActivity.java
@@ -50,7 +50,7 @@ public class GallerySinglePickerActivity extends Activity {
                 Log.d("SinglePicker", "data: " + data.getData().toString());
                 File file = new File(filename);
                 if (file.exists()) {
-                    
+
                     try{
                         fileOrientationHandler.rotateAndReWriteImageFile(file);
                     }catch (IOException e){

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GallerySinglePickerActivity.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/GallerySinglePickerActivity.java
@@ -11,7 +11,10 @@ import android.util.Log;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
+import com.shz.imagepicker.imagepicker.util.FileOrientationHandler;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
 public class GallerySinglePickerActivity extends Activity {
@@ -22,6 +25,8 @@ public class GallerySinglePickerActivity extends Activity {
     private static final int IMAGE_REQUEST_GALLERY = 54563;
 
     private static final String GALLERY_IMAGE_MIME = "image/jpeg";
+    private FileOrientationHandler fileOrientationHandler = new FileOrientationHandler();
+
 
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
@@ -45,6 +50,13 @@ public class GallerySinglePickerActivity extends Activity {
                 Log.d("SinglePicker", "data: " + data.getData().toString());
                 File file = new File(filename);
                 if (file.exists()) {
+                    
+                    try{
+                        fileOrientationHandler.rotateAndReWriteImageFile(file);
+                    }catch (IOException e){
+                        Log.d(this.getClass().getSimpleName(),"Error rotation image "+e.getLocalizedMessage());
+                    }
+
                     files.add(file);
                     mCallback.onImagesSelected(files);
                 }

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/util/FileOrientationHandler.java
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/util/FileOrientationHandler.java
@@ -1,0 +1,66 @@
+package com.shz.imagepicker.imagepicker.util;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.media.ExifInterface;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class FileOrientationHandler {
+
+
+    public void rotateAndReWriteImageFile(File file) throws IOException {
+
+        // Bitmap is rotated according to camera orientation
+        rotateImageIfRequired(file);
+    }
+
+
+    private   void rotateImageIfRequired(File file) throws IOException{
+        ExifInterface ei = new ExifInterface(file.getAbsolutePath());
+        int orientation = ei.getAttributeInt(ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_UNDEFINED);
+
+        Bitmap bitmap = BitmapFactory.decodeFile(file.getAbsolutePath());
+
+        Bitmap rotatedBitmap;
+        switch(orientation) {
+
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                rotatedBitmap = rotateImage(bitmap, 90);
+                saveBitmap(rotatedBitmap,file);
+                break;
+
+            case ExifInterface.ORIENTATION_ROTATE_180:
+                rotatedBitmap = rotateImage(bitmap, 180);
+                saveBitmap(rotatedBitmap,file);
+                break;
+
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                rotatedBitmap = rotateImage(bitmap, 270);
+                saveBitmap(rotatedBitmap,file);
+                break;
+
+            case ExifInterface.ORIENTATION_NORMAL:
+            default:
+        }
+
+    }
+
+    private static Bitmap rotateImage(Bitmap source, float angle) {
+        Matrix matrix = new Matrix();
+        matrix.postRotate(angle);
+        return Bitmap.createBitmap(source, 0, 0, source.getWidth(), source.getHeight(),
+                matrix, true);
+    }
+
+    private void saveBitmap(Bitmap rotatedBitmap,File file) throws IOException{
+        FileOutputStream out = new FileOutputStream(file.getAbsolutePath());
+        rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, out);
+    }
+
+
+}


### PR DESCRIPTION
# Description

Found an issue in multiple devices is that the image is rotated by 90 degrees. Also in Samsung's gallery app multi-select was not enabled when in the image-picker configuration it was enabled.

Fixes # (issue)
Samsung Gallery App : 

-Added an extra property in intent when using multiselection.
- Handled the updated response in onRequestPermissionsResult.

Orientation : 
- Added a class "FileOrientationHandler" that will rotate the image and rewrite the bitmap to that file if the image is rotated.
- Updated All image selection activities to incorporate this class's object.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)