### PR TITLE
Avoid camera crash on `Background process limit - No background processes`

### DIFF
--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/activity/camera/CameraPickerActivity.kt
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/activity/camera/CameraPickerActivity.kt
@@ -38,26 +38,28 @@ internal class CameraPickerActivity : ImagePickerActivity() {
     }
 
     override fun startPicker() {
-        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        filename = System.nanoTime().toString()
-        val uri = getCaptureImageOutputUri(this, filename)
-        if (filename.isNotEmpty()) uri?.path?.let { path ->
-            val file = File(path)
-            if (Build.VERSION.SDK_INT >= 24) {
-                cameraIntent.putExtra(
-                    MediaStore.EXTRA_OUTPUT,
-                    FileProvider.getUriForFile(
-                        this,
-                        authority,
-                        file,
+        if (!authority.isEmpty()) {
+            val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+            filename = System.nanoTime().toString()
+            val uri = getCaptureImageOutputUri(this, filename)
+            if (filename.isNotEmpty()) uri?.path?.let { path ->
+                val file = File(path)
+                if (Build.VERSION.SDK_INT >= 24) {
+                    cameraIntent.putExtra(
+                        MediaStore.EXTRA_OUTPUT,
+                        FileProvider.getUriForFile(
+                            this,
+                            authority,
+                            file,
+                        )
                     )
-                )
-                cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
-                cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            } else {
-                cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
+                    cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                    cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                } else {
+                    cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
+                }
+                launcher.launch(cameraIntent)
             }
-            launcher.launch(cameraIntent)
         }
     }
 

--- a/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/activity/camera/CameraPickerActivity.kt
+++ b/imagepicker/src/main/java/com/shz/imagepicker/imagepicker/activity/camera/CameraPickerActivity.kt
@@ -38,28 +38,26 @@ internal class CameraPickerActivity : ImagePickerActivity() {
     }
 
     override fun startPicker() {
-        if (!authority.isEmpty()) {
-            val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-            filename = System.nanoTime().toString()
-            val uri = getCaptureImageOutputUri(this, filename)
-            if (filename.isNotEmpty()) uri?.path?.let { path ->
-                val file = File(path)
-                if (Build.VERSION.SDK_INT >= 24) {
-                    cameraIntent.putExtra(
-                        MediaStore.EXTRA_OUTPUT,
-                        FileProvider.getUriForFile(
-                            this,
-                            authority,
-                            file,
-                        )
+        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        filename = System.nanoTime().toString()
+        val uri = getCaptureImageOutputUri(this, filename)
+        if (filename.isNotEmpty() && authority.isNotEmpty()) uri?.path?.let { path ->
+            val file = File(path)
+            if (Build.VERSION.SDK_INT >= 24) {
+                cameraIntent.putExtra(
+                    MediaStore.EXTRA_OUTPUT,
+                    FileProvider.getUriForFile(
+                        this,
+                        authority,
+                        file,
                     )
-                    cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
-                    cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                } else {
-                    cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
-                }
-                launcher.launch(cameraIntent)
+                )
+                cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            } else {
+                cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
             }
+            launcher.launch(cameraIntent)
         }
     }
 


### PR DESCRIPTION
#### Changelog
- Fix crash

#### Checklist
- Avoid camera crash on `Background process limit - No background processes`

#### Tested on
- Android 13
